### PR TITLE
Remove auto-install from SessionStart, require Verible

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "gateflow",
       "description": "AI-powered SystemVerilog development assistant with lint fixing, code generation, simulation, and waveform analysis",
-      "version": "1.3.5",
+      "version": "1.4.1",
       "author": {
         "name": "codejunkie99"
       },

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Then add to `~/.claude/settings.json` (global) or `.claude/settings.json` (proje
 |------|----------|-------|-------|
 | [Claude Code](https://code.claude.com/) | Yes | See website | See website |
 | [Verilator](https://verilator.org/) | Yes | `brew install verilator` | `sudo apt install verilator` |
-| Verible | Optional | `brew install verible` | See [releases](https://github.com/chipsalliance/verible/releases) |
+| Verible | Yes | `brew tap chipsalliance/verible && brew install verible` | See [releases](https://github.com/chipsalliance/verible/releases) |
 
 ### Verify Installation
 

--- a/plugins/gateflow/commands/gf-doctor.md
+++ b/plugins/gateflow/commands/gf-doctor.md
@@ -36,7 +36,7 @@ Present a summary table:
 
 ## Missing Dependencies
 
-If any tools are missing, inform the user they will be auto-installed on next session start, or they can install manually:
+If tools are missing, provide manual install steps:
 
 **Manual install (macOS):**
 ```bash
@@ -56,5 +56,4 @@ After verification, list the available GateFlow commands:
 - `/gf-lint` - Run lint
 - `/gf-sim` - Run sim
 - `/gf-gen` - Generate scaffolds
-- `/gf-wave` - Waveforms
 - `/gf-scan` - Index project

--- a/plugins/gateflow/commands/gf-scan.md
+++ b/plugins/gateflow/commands/gf-scan.md
@@ -13,22 +13,17 @@ Index all SystemVerilog files in the current project to build a module database.
 
 ## Instructions
 
-1. Run the gateflow scan command:
-   ```bash
-   gateflow scan
-   ```
-
-2. If gateflow is not installed, use Verilator directly to list modules:
+1. Use Verilator to quickly parse all SV files and surface modules:
    ```bash
    verilator --lint-only -Wall *.sv 2>&1 | head -50
    ```
 
-3. Alternatively, manually discover SV files:
+2. Alternatively, manually discover SV files:
    - Use Glob to find all `**/*.sv` and `**/*.svh` files
    - Read each file to extract module declarations
    - Report the module hierarchy
 
-4. Present results showing:
+3. Present results showing:
    - Total files found
    - Module names and their locations
    - Include file dependencies

--- a/plugins/gateflow/hooks/scripts/check-dependencies.sh
+++ b/plugins/gateflow/hooks/scripts/check-dependencies.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# GateFlow dependency check and auto-install
-# Runs on SessionStart - installs missing deps automatically
+# GateFlow dependency check (no auto-install)
+# Runs on SessionStart - reports missing deps with manual guidance
 
 PLUGIN_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 MARKER_FILE="$PLUGIN_ROOT/.deps-installed"
@@ -36,14 +36,6 @@ show_welcome() {
 EOF
 }
 
-show_installing() {
-    cat << 'EOF'
-    ┌─────────────────────────────────────────────────────┐
-    │  ⚡ Setting up your hardware development environment │
-    └─────────────────────────────────────────────────────┘
-EOF
-}
-
 show_complete() {
     cat << 'EOF'
 
@@ -74,9 +66,8 @@ if ! command -v verible-verilog-syntax &> /dev/null; then
     MISSING+=("verible")
 fi
 
-# All good - silent on subsequent runs
+# All tools present - silent on subsequent runs
 if [ ${#MISSING[@]} -eq 0 ]; then
-    # First successful run - show welcome
     if [ ! -f "$MARKER_FILE" ]; then
         show_welcome
         show_complete
@@ -85,74 +76,22 @@ if [ ${#MISSING[@]} -eq 0 ]; then
     exit 0
 fi
 
-# Already tried to install once - brief warning
-if [ -f "$MARKER_FILE" ]; then
-    echo "⚠ GateFlow: Missing tools: ${MISSING[*]}"
-    echo "  Install manually or delete .deps-installed to retry"
-    exit 0
-fi
-
-# First run - show welcome and install
+# Required dependency missing → report and exit without installing or marking success
 show_welcome
-show_installing
-echo ""
-
-# Auto-install
+echo "⚠ GateFlow: Required tools missing: ${MISSING[*]}"
 if [ "$OS" = "Darwin" ]; then
-    if ! command -v brew &> /dev/null; then
-        echo "    ✗ Homebrew not found"
-        echo "      Install from https://brew.sh then restart Claude"
-        touch "$MARKER_FILE"
-        exit 0
-    fi
-
-    for dep in "${MISSING[@]}"; do
-        case "$dep" in
-            verilator)
-                echo "    → Installing Verilator..."
-                if brew install verilator &> /dev/null; then
-                    echo "    ✓ Verilator installed"
-                else
-                    echo "    ✗ Verilator install failed"
-                fi
-                ;;
-            verible)
-                echo "    → Installing Verible..."
-                brew tap chipsalliance/verible &> /dev/null || true
-                if brew install verible &> /dev/null; then
-                    echo "    ✓ Verible installed"
-                else
-                    echo "    ✗ Verible install failed"
-                fi
-                ;;
-        esac
-    done
-
+    echo "   Install Verilator: brew install verilator"
+    echo "   Install Verible: brew tap chipsalliance/verible && brew install verible"
 elif [ "$OS" = "Linux" ]; then
     if command -v apt-get &> /dev/null; then
-        for dep in "${MISSING[@]}"; do
-            case "$dep" in
-                verilator)
-                    echo "    → Installing Verilator..."
-                    if sudo apt-get update -qq && sudo apt-get install -y verilator &> /dev/null; then
-                        echo "    ✓ Verilator installed"
-                    else
-                        echo "    ✗ Verilator install failed"
-                    fi
-                    ;;
-                verible)
-                    echo "    ℹ Verible: Download from GitHub releases"
-                    echo "      https://github.com/chipsalliance/verible/releases"
-                    ;;
-            esac
-        done
+        echo "   Install Verilator: sudo apt-get update && sudo apt-get install -y verilator"
     else
-        echo "    ℹ Auto-install not supported on this system"
-        echo "      Verilator: https://verilator.org/guide/latest/install.html"
-        echo "      Verible: https://github.com/chipsalliance/verible/releases"
+        echo "   Install Verilator: https://verilator.org/guide/latest/install.html"
     fi
+    echo "   Install Verible: https://github.com/chipsalliance/verible/releases"
+else
+    echo "   Install Verilator from https://verilator.org"
+    echo "   Install Verible from https://github.com/chipsalliance/verible/releases"
 fi
 
-touch "$MARKER_FILE"
-show_complete
 exit 0


### PR DESCRIPTION
## Summary
- Remove auto-install behavior from the SessionStart hook (`check-dependencies.sh`)
- Now reports missing dependencies with manual install instructions instead of silently installing packages
- Keep Verible as a required dependency (not optional)
- Bump version to 1.4.1

## Changes
- **check-dependencies.sh**: Removed auto-install logic, now just shows guidance for manual installation
- **README.md**: Updated Verible install command to include `brew tap` step, marked as required
- **gf-doctor.md**: Removed reference to non-existent `/gf-wave` command
- **gf-scan.md**: Simplified instructions by removing reference to non-existent `gateflow scan` CLI

## Test plan
- [ ] Run `/gf-doctor` with all deps installed → should show success
- [ ] Run `/gf-doctor` with verilator missing → should show manual install instructions
- [ ] Verify no auto-install occurs on SessionStart

🤖 Generated with [Claude Code](https://claude.com/claude-code)