### PR TITLE
Harden GateFlow TUI terminal support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "gateflow",
       "description": "AI-powered hardware development platform \u2014 design, verify, synthesize, release, and deploy working RTL with natural language. 20 agents, 27 skills, 8 IP blocks.",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "author": {
         "name": "codejunkie99",
         "github": "https://github.com/codejunkie99"

--- a/README.md
+++ b/README.md
@@ -590,6 +590,7 @@ For detailed release notes, see [`releases.md`](releases.md).
 
 | Version | Date | What Changed |
 |---------|------|-------------|
+| **2.5.1** | 2026-05-21 | TUI terminal compatibility fixes for cursor and colorless PTYs |
 | **2.5.0** | 2026-05-21 | OpenClaw-style CLI/TUI, release readiness workflow, deterministic validators, synced marketplace/docs/index/mirrors |
 | **2.4.0** | 2026-04-11 | Deep skill enrichment across verification, synthesis, orchestration, architecture, learning, IP, and planning |
 | **2.3.0** | 2026-03-27 | Quality pass, expanded IP docs, new commands, and component reference fixes |

--- a/plugins/gateflow/.claude-plugin/plugin.json
+++ b/plugins/gateflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gateflow",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "AI-powered hardware development platform \u2014 design, verify, synthesize, release, and deploy working RTL with natural language. 20 agents, 27 skills, 8 IP blocks.",
   "author": {
     "name": "codejunkie99",

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,17 @@
 # Releases
 
+## 2.5.1 (2026-05-21) — TUI Terminal Compatibility
+
+Patch release for the GateFlow terminal console.
+
+### Fixes
+- Made the interactive `/gf-tui` curses path tolerate terminals that reject
+  `curs_set(0)`.
+- Added color fallback handling for PTYs with no usable curses color pairs.
+- Added regression coverage for cursor and color capability failures.
+- Updated the release validator default and TUI release check to follow the
+  plugin manifest version.
+
 ## 2.5.0 (2026-05-21) — CLI/TUI + Release Readiness
 
 GateFlow now ships with a deterministic release-prep path so versioned plugin

--- a/tests/test_gateflow_tui.py
+++ b/tests/test_gateflow_tui.py
@@ -36,7 +36,7 @@ class GateFlowTuiTests(unittest.TestCase):
         payload = tui.build_payload(ROOT)
 
         self.assertEqual("gateflow", payload["plugin"]["name"])
-        self.assertEqual("2.5.0", payload["plugin"]["version"])
+        self.assertEqual("2.5.1", payload["plugin"]["version"])
         self.assertEqual(20, payload["inventory"]["agents"])
         self.assertEqual(27, payload["inventory"]["skills"])
         self.assertEqual(21, payload["inventory"]["commands"])
@@ -54,6 +54,46 @@ class GateFlowTuiTests(unittest.TestCase):
         self.assertEqual("", completed.stderr)
         self.assertEqual(0, completed.returncode)
         self.assertIn("GateFlow Terminal", completed.stdout)
+
+    def test_hide_cursor_ignores_unsupported_terminals(self):
+        tui = load_tui()
+
+        class FakeCurses:
+            error = RuntimeError
+
+            @staticmethod
+            def curs_set(_visibility):
+                raise RuntimeError("curs_set() returned ERR")
+
+        self.assertFalse(tui._hide_cursor(FakeCurses))
+
+    def test_terminal_styles_fall_back_without_color_pairs(self):
+        tui = load_tui()
+
+        class FakeCurses:
+            error = RuntimeError
+            COLOR_RED = 1
+            COLOR_GREEN = 2
+            COLOR_YELLOW = 3
+            COLOR_CYAN = 4
+            A_BOLD = 10
+            A_DIM = 20
+
+            @staticmethod
+            def init_pair(_pair, _foreground, _background):
+                raise ValueError("Color pair is greater than COLOR_PAIRS-1")
+
+            @staticmethod
+            def color_pair(_pair):
+                raise AssertionError("color_pair should not be used when init_pair fails")
+
+        styles = tui._terminal_styles(FakeCurses)
+
+        self.assertEqual(FakeCurses.A_BOLD, styles["accent"])
+        self.assertEqual(0, styles["ok"])
+        self.assertEqual(0, styles["warn"])
+        self.assertEqual(FakeCurses.A_DIM, styles["muted"])
+        self.assertEqual(0, styles["footer"])
 
 
 if __name__ == "__main__":

--- a/tests/test_validate_gateflow.py
+++ b/tests/test_validate_gateflow.py
@@ -35,13 +35,13 @@ class GateFlowValidatorTests(unittest.TestCase):
     def test_repository_passes_release_checks(self):
         validator = load_validator()
 
-        result = validator.run_checks(ROOT, expected_version="2.5.0")
+        result = validator.run_checks(ROOT, expected_version="2.5.1")
 
         self.assertEqual([], result.errors)
 
     def test_cli_reports_success(self):
         completed = subprocess.run(
-            [sys.executable, str(VALIDATOR), "--version", "2.5.0"],
+            [sys.executable, str(VALIDATOR), "--version", "2.5.1"],
             cwd=ROOT,
             text=True,
             capture_output=True,

--- a/tools/gateflow_tui.py
+++ b/tools/gateflow_tui.py
@@ -51,8 +51,9 @@ def build_payload(root: Path) -> dict:
     root = root.resolve()
     validator = _load_validator()
     inventory = validator.discover_inventory(root)
-    release = validator.run_checks(root, expected_version="2.5.0")
     plugin = _read_json(root / "plugins" / "gateflow" / ".claude-plugin" / "plugin.json")
+    plugin_version = plugin.get("version", "unknown")
+    release = validator.run_checks(root, expected_version=plugin_version)
 
     health = {
         "doctor": "ready" if (root / "plugins/gateflow/commands/gf-doctor.md").exists() else "missing",
@@ -76,7 +77,7 @@ def build_payload(root: Path) -> dict:
     return {
         "mode": "OpenClaw-style local mode",
         "workspace": str(root),
-        "plugin": {"name": plugin.get("name", "gateflow"), "version": plugin.get("version", "unknown")},
+        "plugin": {"name": plugin.get("name", "gateflow"), "version": plugin_version},
         "inventory": {
             "agents": len(inventory.agents),
             "skills": len(inventory.skills),
@@ -101,6 +102,40 @@ def _status(value: str | dict, plain: bool) -> str:
     if value in {"missing", "unknown"} or "issues" in value:
         return _color(value, WARN, plain)
     return value
+
+
+def _hide_cursor(curses_module=curses) -> bool:
+    try:
+        curses_module.curs_set(0)
+    except curses_module.error:
+        return False
+    return True
+
+
+def _terminal_styles(curses_module=curses) -> dict[str, int]:
+    styles = {
+        "accent": getattr(curses_module, "A_BOLD", 0),
+        "ok": 0,
+        "warn": 0,
+        "muted": getattr(curses_module, "A_DIM", 0),
+        "footer": 0,
+    }
+    try:
+        curses_module.init_pair(1, curses_module.COLOR_RED, -1)
+        curses_module.init_pair(2, curses_module.COLOR_GREEN, -1)
+        curses_module.init_pair(3, curses_module.COLOR_YELLOW, -1)
+        curses_module.init_pair(4, curses_module.COLOR_CYAN, -1)
+        styles.update(
+            {
+                "accent": curses_module.color_pair(1) | getattr(curses_module, "A_BOLD", 0),
+                "ok": curses_module.color_pair(2),
+                "warn": curses_module.color_pair(3),
+                "footer": curses_module.color_pair(4),
+            }
+        )
+    except (curses_module.error, ValueError):
+        pass
+    return styles
 
 
 def render_snapshot(root: Path, plain: bool = False) -> str:
@@ -153,14 +188,11 @@ def _draw(stdscr, payload: dict, selected: int, message: str) -> None:
         if 0 <= y < height:
             stdscr.addnstr(y, x, text, max(0, width - x - 1), attr)
 
-    curses.init_pair(1, curses.COLOR_RED, -1)
-    curses.init_pair(2, curses.COLOR_GREEN, -1)
-    curses.init_pair(3, curses.COLOR_YELLOW, -1)
-    curses.init_pair(4, curses.COLOR_CYAN, -1)
-    accent = curses.color_pair(1) | curses.A_BOLD
-    ok = curses.color_pair(2)
-    warn = curses.color_pair(3)
-    muted = curses.A_DIM
+    styles = _terminal_styles()
+    accent = styles["accent"]
+    ok = styles["ok"]
+    warn = styles["warn"]
+    muted = styles["muted"]
 
     add(0, 0, " GateFlow Terminal ", accent)
     add(0, 20, payload["mode"], muted)
@@ -196,7 +228,7 @@ def _draw(stdscr, payload: dict, selected: int, message: str) -> None:
 
     footer = message or "↑/↓ select   Enter show command   r refresh   q quit"
     add(height - 2, 0, "─" * (width - 1), muted)
-    add(height - 1, 1, footer, curses.color_pair(4))
+    add(height - 1, 1, footer, styles["footer"])
     stdscr.refresh()
 
 
@@ -204,7 +236,7 @@ def run_interactive(root: Path) -> int:
     payload = build_payload(root)
 
     def wrapped(stdscr) -> None:
-        curses.curs_set(0)
+        _hide_cursor()
         stdscr.keypad(True)
         selected = 0
         message = ""

--- a/tools/validate_gateflow.py
+++ b/tools/validate_gateflow.py
@@ -132,7 +132,7 @@ def _check_symlink(path: Path, expected_target: str, errors: list[str]) -> None:
         errors.append(f"{path} points to {target}, expected {expected_target}")
 
 
-def run_checks(root: Path, expected_version: str = "2.5.0") -> ValidationResult:
+def run_checks(root: Path, expected_version: str = "2.5.1") -> ValidationResult:
     root = root.resolve()
     inventory = discover_inventory(root)
     errors: list[str] = []
@@ -148,7 +148,7 @@ def run_checks(root: Path, expected_version: str = "2.5.0") -> ValidationResult:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", type=Path, default=Path.cwd(), help="Repository root")
-    parser.add_argument("--version", default="2.5.0", help="Expected release version")
+    parser.add_argument("--version", default="2.5.1", help="Expected release version")
     args = parser.parse_args(argv)
 
     result = run_checks(args.root, expected_version=args.version)


### PR DESCRIPTION
## Summary
- Make the interactive `/gf-tui` curses path tolerate terminals that reject `curs_set(0)`.
- Add fallback styling for PTYs without usable curses color pairs.
- Bump plugin and marketplace metadata to `2.5.1` and add patch release notes.
- Add regression tests for cursor and color capability failures.

## Verification
- `python3 -m unittest`
- `python3 tools/validate_gateflow.py --version 2.5.1`
- `python3 tools/gateflow_tui.py --snapshot --plain`
- `python3 tools/gateflow_tui.py --json`
- interactive PTY smoke: `python3 tools/gateflow_tui.py`, then `q` exits with code 0
- `git diff --check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden GateFlow TUI terminal support for cursor and color pair failures
> - Adds `_hide_cursor` helper in [gateflow_tui.py](https://github.com/codejunkie99/Gateflow-Plugin/pull/9/files#diff-fdcdea8fbeabdb65e78ab99bdf678cf106e782d6b0e1cac6a5d65c762976092e) that swallows `curses.error` when `curs_set` is unsupported, replacing a direct call that would raise in colorless PTYs.
> - Adds `_terminal_styles` helper that attempts color pair initialization and falls back to monochrome attributes on failure, preventing draw errors in terminals without color support.
> - Updates `build_payload` to read the plugin version from [plugin.json](https://github.com/codejunkie99/Gateflow-Plugin/pull/9/files#diff-aedf0513dc382cc99344604e8475310736277390b36de0ae297f93c4f67655c1) instead of a hardcoded string.
> - Bumps plugin version to 2.5.1 across manifests, validator defaults, and test assertions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1bd07c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->